### PR TITLE
fix: Explicitly disable client certificate auth (deprecated by kubernetes)

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -19,6 +19,15 @@ resource "google_container_cluster" "default" {
 
   remove_default_node_pool = true
   initial_node_count       = 1
+
+  # Disable client certificate authentication, which reduces the attack surface 
+  # for the cluster by disabling this deprecated feature. It defaults to false, 
+  # but this will make it explicit and quiet some security tooling.
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
 }
 
 resource "google_container_node_pool" "default" {


### PR DESCRIPTION
Disable client certificate authentication, which in general reduces the attack surface for the cluster by disabling this deprecated feature. It defaults to false anyway (i.e. this is already the current setting in the cluster), but this will make it explicit and quiet some security tooling.