### PR TITLE
refactor: Updates to exclusively create a VPC network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ override.tf.json
 # example: *tfplan*
 
 .DS_Store
+.idea/
 *.tfvars
 
 .terraform.lock*

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -3,6 +3,10 @@ resource "google_compute_network" "default" {
   name                    = "${var.namespace}-vpc"
   description             = "${var.namespace} VPC Network"
   auto_create_subnetworks = false
+  project = var.project
+
+   # A global routing mode can have an unexpected impact on load balancers; always use a regional mode
+  routing_mode = "REGIONAL"
 }
 
 # VM instances and other resources to communicate with each other via internal,
@@ -11,6 +15,10 @@ resource "google_compute_subnetwork" "default" {
   name          = "${var.namespace}-subnet"
   ip_cidr_range = "10.10.0.0/16"
   network       = google_compute_network.default.self_link
+  project = var.project
+  region  = var.region
+
+  private_ip_google_access = true
 
   depends_on = [google_compute_network.default]
 }
@@ -21,6 +29,7 @@ resource "google_compute_global_address" "private_ip_address" {
   address_type  = "INTERNAL"
   prefix_length = 16
   network       = google_compute_network.default.id
+  project = var.project
 
   depends_on = [google_compute_network.default]
 }

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -18,6 +18,8 @@ resource "google_compute_subnetwork" "default" {
   project = var.project
   region  = var.region
 
+  # When enabled, VMs in this subnetwork without external IP addresses can access Google APIs 
+  # and services by using Private Google Access.
   private_ip_google_access = true
 
   depends_on = [google_compute_network.default]

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -3,9 +3,9 @@ resource "google_compute_network" "default" {
   name                    = "${var.namespace}-vpc"
   description             = "${var.namespace} VPC Network"
   auto_create_subnetworks = false
-  project = var.project
+  project                 = var.project
 
-   # A global routing mode can have an unexpected impact on load balancers; always use a regional mode
+  # A global routing mode can have an unexpected impact on load balancers; always use a regional mode
   routing_mode = "REGIONAL"
 }
 
@@ -15,8 +15,8 @@ resource "google_compute_subnetwork" "default" {
   name          = "${var.namespace}-subnet"
   ip_cidr_range = "10.10.0.0/16"
   network       = google_compute_network.default.self_link
-  project = var.project
-  region  = var.region
+  project       = var.project
+  region        = var.region
 
   # When enabled, VMs in this subnetwork without external IP addresses can access Google APIs 
   # and services by using Private Google Access.
@@ -31,7 +31,7 @@ resource "google_compute_global_address" "private_ip_address" {
   address_type  = "INTERNAL"
   prefix_length = 16
   network       = google_compute_network.default.id
-  project = var.project
+  project       = var.project
 
   depends_on = [google_compute_network.default]
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -2,3 +2,12 @@ variable "namespace" {
   description = "The application name used as a prefix for all resources created."
   type        = string
 }
+variable "project" {
+  description = "Project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "Google region"
+  type        = string
+}


### PR DESCRIPTION
Updates to networking module (variables and main) to be able to 
* exclusively create a VPC network.
* private_ip_google_access = true, When enabled, VMs in this subnetwork without external IP addresses can access Google APIs and services by using Private Google Access.
