### PR TITLE
feat!: Enable cluster auto-scaling, auto-repairs and auto-upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<p float="left" align="middle" style="margin-bottom: 20px">
-    <img width="100" src="https://www.datocms-assets.com/2885/1620155116-brandhcterraformverticalcolor.svg" style="margin-right: 25px">
-    <img width="100" src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Google-cloud-platform.svg/800px-Google-cloud-platform.svg.png" style="margin-right: 5px">
-    <img width="300" src="https://github.com/dagster-io/dagster/raw/master/assets/dagster-logo.png">
-</p>
-
 # terraform-google-dagster
 Terraform module to provision required GCP infrastructure necessary for a Dagster Kubernetes-based deployment.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can find an example deployment utilizing the official [Dagster Helm chart](h
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.30.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.13.0 |
 
 ## Modules
 
@@ -65,7 +65,7 @@ You can find an example deployment utilizing the official [Dagster Helm chart](h
 | <a name="input_cloudsql_postgres_version"></a> [cloudsql\_postgres\_version](#input\_cloudsql\_postgres\_version) | The postgres version of the CloudSQL instance. | `string` | `"POSTGRES_14"` | no |
 | <a name="input_cloudsql_tier"></a> [cloudsql\_tier](#input\_cloudsql\_tier) | The machine type to use | `string` | `"db-f1-micro"` | no |
 | <a name="input_cluster_compute_machine_type"></a> [cluster\_compute\_machine\_type](#input\_cluster\_compute\_machine\_type) | Compute machine type to deploy cluster nodes on. | `string` | `"e2-standard-2"` | no |
-| <a name="input_cluster_node_count"></a> [cluster\_node\_count](#input\_cluster\_node\_count) | Number of nodes to create in cluster. | `number` | `2` | no |
+| <a name="input_cluster_node_pool_max_node_count"></a> [cluster\_node\_pool\_max\_node\_count](#input\_cluster\_node\_pool\_max\_node\_count) | Max number of nodes cluster can scale up to. | `number` | `2` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Indicates whether or not storage and databases have deletion protection enabled | `bool` | `true` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace used as a prefix for all resources | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ to follow these guidelines when submitting any contributions of your own.
 | <a name="input_cloudsql_postgres_version"></a> [cloudsql\_postgres\_version](#input\_cloudsql\_postgres\_version) | The postgres version of the CloudSQL instance. | `string` | `"POSTGRES_14"` | no |
 | <a name="input_cloudsql_tier"></a> [cloudsql\_tier](#input\_cloudsql\_tier) | The machine type to use | `string` | `"db-f1-micro"` | no |
 | <a name="input_cluster_compute_machine_type"></a> [cluster\_compute\_machine\_type](#input\_cluster\_compute\_machine\_type) | Compute machine type to deploy cluster nodes on. | `string` | `"e2-standard-2"` | no |
-| <a name="input_cluster_node_count"></a> [cluster\_node\_count](#input\_cluster\_node\_count) | Number of nodes to create in cluster. | `number` | `2` | no |
+| <a name="input_cluster_node_pool_max_node_count"></a> [cluster\_node\_pool\_max\_node\_count](#input\_cluster\_node\_pool\_max\_node\_count) | Max number of nodes cluster can scale up to. | `number` | `2` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Indicates whether or not storage and databases have deletion protection enabled | `bool` | `true` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace used as a prefix for all resources | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID | `string` | n/a | yes |

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -36,8 +36,8 @@ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.30.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.6.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.15.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.4.1 |
 
 ## Modules
 

--- a/example-app/main.tf
+++ b/example-app/main.tf
@@ -30,7 +30,7 @@ module "dagster_infra" {
   # cloudsql_tier (default db-f1-micro)
   # cloudsql_availability_type (default ZONAL)
   # cluster_compute_machine_type (default e2-standard-2)
-  # cluster_node_count (default 2)
+  # cluster_node_pool_max_node_count (default 2)
   # deletion_protection (default true)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -58,11 +58,11 @@ module "networking" {
 }
 
 module "cluster" {
-  source                       = "./modules/cluster"
-  namespace                    = var.namespace
-  project_id                   = var.project_id
-  cluster_compute_machine_type = var.cluster_compute_machine_type
-  cluster_node_count           = var.cluster_node_count
+  source                           = "./modules/cluster"
+  namespace                        = var.namespace
+  project_id                       = var.project_id
+  cluster_compute_machine_type     = var.cluster_compute_machine_type
+  cluster_node_pool_max_node_count = var.cluster_node_pool_max_node_count
 
   network         = module.networking.network
   subnetwork      = module.networking.subnetwork

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -13,8 +13,8 @@ variable "cluster_compute_machine_type" {
   type        = string
 }
 
-variable "cluster_node_count" {
-  description = "Number of nodes to create in cluster."
+variable "cluster_node_pool_max_node_count" {
+  description = "Max number of nodes cluster can scale up to."
   type        = number
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -54,8 +54,8 @@ variable "cluster_compute_machine_type" {
   default     = "e2-standard-2"
 }
 
-variable "cluster_node_count" {
-  description = "Number of nodes to create in cluster."
+variable "cluster_node_pool_max_node_count" {
+  description = "Max number of nodes cluster can scale up to."
   type        = number
   default     = 2
 }


### PR DESCRIPTION
This will enable the use of autoscaling node pools which will allow us to increase the number of available nodes based on current demand capacity. Additionally, it enables auto-repair and auto-updates which will keep our Kubernetes cluster up to date in accordance with the [`STABLE`](https://cloud.google.com/kubernetes-engine/docs/release-notes-stable) release channel.