### PR TITLE
feat: Migrate out of legacy module configuration

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.5.3

--- a/README.md
+++ b/README.md
@@ -23,15 +23,11 @@ You can find an example deployment utilizing the official [Dagster Helm chart](h
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.13 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, < 2.0.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.30.0 |
+No providers.
 
 ## Modules
 
@@ -47,9 +43,7 @@ You can find an example deployment utilizing the official [Dagster Helm chart](h
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
+No resources.
 
 ## Inputs
 
@@ -65,7 +59,6 @@ You can find an example deployment utilizing the official [Dagster Helm chart](h
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace used as a prefix for all resources | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Google region | `string` | n/a | yes |
-| <a name="input_zone"></a> [zone](#input\_zone) | Google zone | `string` | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -105,14 +105,11 @@ to follow these guidelines when submitting any contributions of your own.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.13 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, < 2.0.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.13 |
+No providers.
 
 ## Modules
 
@@ -128,9 +125,7 @@ to follow these guidelines when submitting any contributions of your own.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
+No resources.
 
 ## Inputs
 
@@ -146,7 +141,6 @@ to follow these guidelines when submitting any contributions of your own.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace used as a prefix for all resources | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Google region | `string` | n/a | yes |
-| <a name="input_zone"></a> [zone](#input\_zone) | Google zone | `string` | n/a | yes |
 
 ## Outputs
 

--- a/example-app/.tool-versions
+++ b/example-app/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.5.3

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -29,16 +29,17 @@ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | =1.5.3 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.13 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.4 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.9 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.30.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.6.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.77.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.10.1 |
 
 ## Modules
 

--- a/example-app/main.tf
+++ b/example-app/main.tf
@@ -1,5 +1,11 @@
 terraform {
+  required_version = "=1.5.3"
+
   required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.9"
+    }
     google = {
       source  = "hashicorp/google"
       version = "~> 4.13"
@@ -22,7 +28,6 @@ module "dagster_infra" {
   source     = "../"
   project_id = var.project_id
   region     = var.region
-  zone       = var.zone
   namespace  = var.namespace
 
   # cloud_storage_bucket_location (default US)
@@ -35,6 +40,12 @@ module "dagster_infra" {
 }
 
 data "google_client_config" "current" {}
+
+provider "kubernetes" {
+  host                   = "https://${module.dagster_infra.cluster_endpoint}"
+  cluster_ca_certificate = base64decode(module.dagster_infra.cluster_ca_certificate)
+  token                  = data.google_client_config.current.access_token
+}
 
 provider "helm" {
   kubernetes {

--- a/main.tf
+++ b/main.tf
@@ -20,20 +20,6 @@ module "project_factory_project_services" {
   disable_services_on_destroy = false
 }
 
-# Required for Artifact Registry. Google provider does not have
-# support for this cloud resource.
-provider "google-beta" {
-  project = var.project_id
-  region  = var.region
-  zone    = var.zone
-}
-
-provider "google" {
-  project = var.project_id
-  region  = var.region
-  zone    = var.zone
-}
-
 module "service_account" {
   source    = "./modules/service_account"
   namespace = var.namespace
@@ -82,14 +68,6 @@ module "database" {
   network_connection = module.networking.connection
 
   depends_on = [module.networking]
-}
-
-data "google_client_config" "current" {}
-
-provider "kubernetes" {
-  host                   = "https://${module.cluster.cluster_endpoint}"
-  cluster_ca_certificate = base64decode(module.cluster.cluster_ca_certificate)
-  token                  = data.google_client_config.current.access_token
 }
 
 module "registry" {

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5.0, < 2.0.0"
+
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -1,5 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0, < 2.0.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.30"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.9"
+    }
+  }
+}
+
 resource "google_artifact_registry_repository" "default" {
-  provider      = google-beta
   format        = "DOCKER"
   location      = var.location
   repository_id = "${var.namespace}-registry"
@@ -9,7 +23,6 @@ resource "google_artifact_registry_repository" "default" {
 # This service account will be used by the Kubernetes cluster when accessing
 # code deployment images in the private repository.
 resource "google_artifact_registry_repository_iam_member" "access" {
-  provider   = google-beta
   project    = google_artifact_registry_repository.default.project
   location   = google_artifact_registry_repository.default.location
   repository = google_artifact_registry_repository.default.name
@@ -30,7 +43,7 @@ resource "kubernetes_secret" "image_pull_secret" {
     ".dockerconfigjson" = jsonencode({
       auths = {
         "https://${google_artifact_registry_repository.default.id}-docker.pkg.dev" = {
-          auth = "${base64encode("_json_key:${var.service_account_credentials}")}"
+          auth = base64encode("_json_key:${var.service_account_credentials}")
         }
       }
     })

--- a/variables.tf
+++ b/variables.tf
@@ -8,11 +8,6 @@ variable "region" {
   type        = string
 }
 
-variable "zone" {
-  description = "Google zone"
-  type        = string
-}
-
 variable "namespace" {
   description = "Namespace used as a prefix for all resources"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,12 +1,3 @@
 terraform {
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 4.13"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.9"
-    }
-  }
+  required_version = ">= 1.5.0, < 2.0.0"
 }


### PR DESCRIPTION
Converts the module into a [non-legacy](https://developer.hashicorp.com/terraform/language/modules/develop/providers#legacy-shared-modules-with-provider-configurations) module by removing any provider configuration. The config will come from the parent module. I also fixed linting issues.