### PR TITLE
feat: Public IP address

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -35,7 +35,10 @@ resource "google_sql_database_instance" "default" {
     availability_type = var.cloudsql_availability_type
 
     ip_configuration {
-      ipv4_enabled    = false
+      # We're giving the Cloud SQL instance a public IP address in order to connect to it with
+      # Cloud SQL Proxy (which requires IAM authentication). We're not exposing the instance
+      # to the internet because no external network is authorized.
+      ipv4_enabled    = true
       private_network = var.network_connection.network
     }
 


### PR DESCRIPTION
Enabling public IP address on the Cloud SQL instance for Cloud SQL Proxy

![ScreenShot 2023-10-26 at 19 56 30@2x](https://github.com/wandb/terraform-google-dagster/assets/24848602/af7d6857-baf5-433f-b838-9792674f9efa)
