### PR TITLE
feat: Increase CloudSQL active connections

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -47,6 +47,11 @@ resource "google_sql_database_instance" "default" {
       value = "on"
     }
 
+    database_flags {
+      name  = "max_connections"
+      value = "1000"
+    }
+
     backup_configuration {
       backup_retention_settings {
         retained_backups = 7


### PR DESCRIPTION
Increase active CloudSQL connections to 1000 instead of the default