### PR TITLE
feat: Private GKE cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ No resources.
 | <a name="output_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#output\_cluster\_ca\_certificate) | Cluster certificate of provisioned Kubernetes cluster |
 | <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | Endpoint of provisioned Kubernetes cluster |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | Id of provisioned Kubernetes cluster |
+| <a name="output_network_name"></a> [network\_name](#output\_network\_name) | Name of provisioned VPC network |
 | <a name="output_registry_image_path"></a> [registry\_image\_path](#output\_registry\_image\_path) | Docker image path of provisioned Artifact Registry |
 | <a name="output_registry_image_pull_secret"></a> [registry\_image\_pull\_secret](#output\_registry\_image\_pull\_secret) | Name of Kubernetes secret containing Docker config with permissions to pull from private Artifact Registry repository |
 | <a name="output_registry_location"></a> [registry\_location](#output\_registry\_location) | Location of provisioned Artifact Registry |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ No resources.
 | <a name="output_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#output\_cluster\_ca\_certificate) | Cluster certificate of provisioned Kubernetes cluster |
 | <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | Endpoint of provisioned Kubernetes cluster |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | Id of provisioned Kubernetes cluster |
+| <a name="output_network_name"></a> [network\_name](#output\_network\_name) | Name of provisioned VPC network |
 | <a name="output_registry_image_path"></a> [registry\_image\_path](#output\_registry\_image\_path) | Docker image path of provisioned Artifact Registry |
 | <a name="output_registry_image_pull_secret"></a> [registry\_image\_pull\_secret](#output\_registry\_image\_pull\_secret) | Name of Kubernetes secret containing Docker config with permissions to pull from private Artifact Registry repository |
 | <a name="output_registry_location"></a> [registry\_location](#output\_registry\_location) | Location of provisioned Artifact Registry |

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -82,6 +82,11 @@ resource "google_container_node_pool" "default" {
     ]
   }
 
+  network_config {
+    # Isolate nodes from the internet by default. Internet access is granted with NAT.
+    enable_private_nodes = true
+  }
+
   lifecycle {
     ignore_changes = [
       location,

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,3 +49,8 @@ output "registry_image_pull_secret" {
   description = "Name of Kubernetes secret containing Docker config with permissions to pull from private Artifact Registry repository"
   value       = module.registry.registry_image_pull_secret
 }
+
+output "network_name" {
+  description = "Name of provisioned VPC network"
+  value       = module.networking.network.name
+}


### PR DESCRIPTION
Turn the GKE cluster into a [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters) which isolate nodes from the internet by default. Internet access is granted with NAT.

Also outputs the network name for NAT configuration downstream.