### PR TITLE
feat: Collect GKE metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ No resources.
 | <a name="input_cloudsql_postgres_version"></a> [cloudsql\_postgres\_version](#input\_cloudsql\_postgres\_version) | The postgres version of the CloudSQL instance. | `string` | `"POSTGRES_14"` | no |
 | <a name="input_cloudsql_tier"></a> [cloudsql\_tier](#input\_cloudsql\_tier) | The machine type to use | `string` | `"db-f1-micro"` | no |
 | <a name="input_cluster_compute_machine_type"></a> [cluster\_compute\_machine\_type](#input\_cluster\_compute\_machine\_type) | Compute machine type to deploy cluster nodes on. | `string` | `"e2-standard-2"` | no |
+| <a name="input_cluster_monitoring_components"></a> [cluster\_monitoring\_components](#input\_cluster\_monitoring\_components) | Components to enable in the GKE monitoring stack. | `list(string)` | <pre>[<br>  "SYSTEM_COMPONENTS"<br>]</pre> | no |
 | <a name="input_cluster_node_pool_max_node_count"></a> [cluster\_node\_pool\_max\_node\_count](#input\_cluster\_node\_pool\_max\_node\_count) | Max number of nodes cluster can scale up to. | `number` | `2` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Indicates whether or not storage and databases have deletion protection enabled | `bool` | `true` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | The domain in which your Google Groups are defined. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ No resources.
 | <a name="input_cloudsql_postgres_version"></a> [cloudsql\_postgres\_version](#input\_cloudsql\_postgres\_version) | The postgres version of the CloudSQL instance. | `string` | `"POSTGRES_14"` | no |
 | <a name="input_cloudsql_tier"></a> [cloudsql\_tier](#input\_cloudsql\_tier) | The machine type to use | `string` | `"db-f1-micro"` | no |
 | <a name="input_cluster_compute_machine_type"></a> [cluster\_compute\_machine\_type](#input\_cluster\_compute\_machine\_type) | Compute machine type to deploy cluster nodes on. | `string` | `"e2-standard-2"` | no |
+| <a name="input_cluster_monitoring_components"></a> [cluster\_monitoring\_components](#input\_cluster\_monitoring\_components) | Components to enable in the GKE monitoring stack. | `list(string)` | <pre>[<br>  "SYSTEM_COMPONENTS"<br>]</pre> | no |
 | <a name="input_cluster_node_pool_max_node_count"></a> [cluster\_node\_pool\_max\_node\_count](#input\_cluster\_node\_pool\_max\_node\_count) | Max number of nodes cluster can scale up to. | `number` | `2` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Indicates whether or not storage and databases have deletion protection enabled | `bool` | `true` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | The domain in which your Google Groups are defined. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -21,8 +21,9 @@ module "project_factory_project_services" {
 }
 
 module "service_account" {
-  source    = "./modules/service_account"
-  namespace = var.namespace
+  source     = "./modules/service_account"
+  project_id = var.project_id
+  namespace  = var.namespace
 }
 
 module "storage" {
@@ -50,6 +51,7 @@ module "cluster" {
   cluster_compute_machine_type     = var.cluster_compute_machine_type
   cluster_node_pool_max_node_count = var.cluster_node_pool_max_node_count
   domain                           = var.domain
+  cluster_monitoring_components    = var.cluster_monitoring_components
 
   network         = module.networking.network
   subnetwork      = module.networking.subnetwork

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -32,6 +32,10 @@ resource "google_container_cluster" "default" {
     channel = "STABLE"
   }
 
+  monitoring_config {
+    enable_components = var.cluster_monitoring_components
+  }
+
   remove_default_node_pool = true
   initial_node_count       = 1
 
@@ -68,18 +72,6 @@ resource "google_container_node_pool" "default" {
   node_config {
     machine_type    = var.cluster_compute_machine_type
     service_account = var.service_account.email
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/bigtable.admin",
-      "https://www.googleapis.com/auth/bigtable.data",
-      "https://www.googleapis.com/auth/bigquery",
-      "https://www.googleapis.com/auth/cloud-platform",
-      "https://www.googleapis.com/auth/devstorage.read_write",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/pubsub",
-      "https://www.googleapis.com/auth/trace.append",
-      "https://www.googleapis.com/auth/sqlservice.admin",
-    ]
   }
 
   network_config {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -18,6 +18,12 @@ variable "cluster_node_pool_max_node_count" {
   type        = number
 }
 
+variable "cluster_monitoring_components" {
+  description = "Components to enable in the GKE monitoring stack."
+  type        = list(string)
+  default     = []
+}
+
 variable "service_account" {
   description = "The service account associated with the GKE cluster instances that host Dagster."
   type        = object({ email = string })

--- a/modules/service_account/main.tf
+++ b/modules/service_account/main.tf
@@ -1,3 +1,18 @@
+terraform {
+  required_version = ">= 1.5.0, < 2.0.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.30"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
 resource "random_id" "default" {
   # 30 bytes ensures that enough characters are generated to satisfy the service account ID requirements, regardless of
   # the prefix.
@@ -8,12 +23,30 @@ resource "random_id" "default" {
 resource "google_service_account" "default" {
   # Limit the string used to 30 characters.
   account_id   = substr(random_id.default.dec, 0, 30)
-  display_name = var.namespace
-  description  = "Service Account used by ${var.namespace}."
+  display_name = "GKE node pool Service Account"
+  description  = "Used by GKE node pools in ${var.namespace}."
 }
 
 resource "google_service_account_key" "default" {
   service_account_id = google_service_account.default.name
 
   depends_on = [google_service_account.default]
+}
+
+locals {
+  roles = [
+    "roles/monitoring.viewer",
+    "roles/monitoring.metricWriter",
+    "roles/logging.logWriter",
+    "roles/stackdriver.resourceMetadata.writer",
+    "roles/autoscaling.metricsWriter"
+  ]
+}
+
+resource "google_project_iam_member" "roles" {
+  for_each = toset(local.roles)
+
+  project = var.project_id
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.default.email}"
 }

--- a/modules/service_account/variables.tf
+++ b/modules/service_account/variables.tf
@@ -1,3 +1,8 @@
+variable "project_id" {
+  description = "Project ID"
+  type        = string
+}
+
 variable "namespace" {
   description = "The namespace name used as a prefix for all resources created."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "cluster_node_pool_max_node_count" {
   default     = 2
 }
 
+variable "cluster_monitoring_components" {
+  description = "Components to enable in the GKE monitoring stack."
+  type        = list(string)
+  default     = ["SYSTEM_COMPONENTS"]
+}
+
 variable "domain" {
   description = "The domain in which your Google Groups are defined."
   type        = string


### PR DESCRIPTION
This PR enables the collection of GKE metrics by default. Additionally, it removes the use of access scopes on the GKE node pool Service Account (SA), replacing it with a more secure, least privilege approach using IAM permissions. 

This enhancement improves security and ensures that only the necessary permissions are granted for metric collection.

References:
- https://cloud.google.com/kubernetes-engine/docs/how-to/configure-metrics
- https://cloud.google.com/kubernetes-engine/docs/how-to/access-scopes