### PR TITLE
fix: Fix the domain name formatting -- dont add the .com universally

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -21,7 +21,7 @@ resource "google_container_cluster" "default" {
   }
 
   authenticator_groups_config {
-    security_group = "gke-security-groups@${var.domain}.com"
+    security_group = "gke-security-groups@${var.domain}"
   }
 
   workload_identity_config {


### PR DESCRIPTION
Existing implementation assumes `.com` domain, which doesn't work for other domain names.
Happy to opt in for another solution!