### PR TITLE
fix: widen google provider constraint to allow v7.x

### DIFF
--- a/example-app/main.tf
+++ b/example-app/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = ">= 6.0, < 8.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = ">= 6.0, < 8.0"
     }
   }
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = ">= 6.0, < 8.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = ">= 6.0, < 8.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/service_account/main.tf
+++ b/modules/service_account/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = ">= 6.0, < 8.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = ">= 6.0, < 8.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Summary

- Widens the `hashicorp/google` provider constraint in all submodules from `~> 6.0` to `>= 6.0, < 8.0`
- Affected modules: `cluster`, `database`, `registry`, `service_account`, `storage`
- Remains fully compatible with google provider v6.x while also allowing v7.x

## Motivation

The production workspace needs v7.x to resolve a known race condition bug in `google_cloud_run_v2_service_iam_member`, where the provider produces inconsistent results after apply due to IAM API eventual consistency.

The current `~> 6.0` pin in these submodules blocks the upgrade. Widening to `>= 6.0, < 8.0` allows both 6.x and 7.x to satisfy the constraint, unblocking the internal TF upgrade while maintaining backward compatibility.