### PR TITLE
feat: replace SA key imagePullSecret with Workload Identity node-level GAR access

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ No resources.
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | Id of provisioned Kubernetes cluster |
 | <a name="output_network_name"></a> [network\_name](#output\_network\_name) | Name of provisioned VPC network |
 | <a name="output_registry_image_path"></a> [registry\_image\_path](#output\_registry\_image\_path) | Docker image path of provisioned Artifact Registry |
-| <a name="output_registry_image_pull_secret"></a> [registry\_image\_pull\_secret](#output\_registry\_image\_pull\_secret) | Name of Kubernetes secret containing Docker config with permissions to pull from private Artifact Registry repository |
 | <a name="output_registry_location"></a> [registry\_location](#output\_registry\_location) | Location of provisioned Artifact Registry |
 | <a name="output_registry_name"></a> [registry\_name](#output\_registry\_name) | Name of provisioned Artifact Registry |
 | <a name="output_service_account"></a> [service\_account](#output\_service\_account) | Service account created to manage and authenticate services. |

--- a/main.tf
+++ b/main.tf
@@ -80,10 +80,7 @@ module "registry" {
   namespace = var.namespace
   location  = var.region
 
-  service_account             = module.service_account.service_account
-  service_account_credentials = module.service_account.service_account_credentials
+  service_account = module.service_account.service_account
 
-  # Depends on cluster existing as Kubernetes secret will be created containing an imagePullSecret
-  # with Docker config for private registry
   depends_on = [module.cluster, module.service_account]
 }

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.9"
-    }
   }
 }
 
@@ -27,36 +23,15 @@ resource "google_artifact_registry_repository" "default" {
   }
 }
 
-# Grants pull access for the registry to the project's service account
-# This service account will be used by the Kubernetes cluster when accessing
-# code deployment images in the private repository.
+# Grants the GKE node service account read access to the registry.
+# With GKE Workload Identity enabled on the cluster, the kubelet uses the node
+# SA credentials to pull images without any imagePullSecrets.
 resource "google_artifact_registry_repository_iam_member" "access" {
   project    = google_artifact_registry_repository.default.project
   location   = google_artifact_registry_repository.default.location
   repository = google_artifact_registry_repository.default.name
-  role       = "roles/viewer"
+  role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:${var.service_account.email}"
 
   depends_on = [google_artifact_registry_repository.default]
-}
-
-# Grants permissions to pull images from Artifact Registry.
-# This must be used as an imagePullSecret to access private images.
-resource "kubernetes_secret" "image_pull_secret" {
-  metadata {
-    name = "artifact-registry"
-  }
-
-  data = {
-    ".dockerconfigjson" = jsonencode({
-      auths = {
-        "https://${google_artifact_registry_repository.default.id}-docker.pkg.dev" = {
-          auth = base64encode("_json_key:${var.service_account_credentials}")
-        }
-      }
-    })
-  }
-
-  type       = "kubernetes.io/dockerconfigjson"
-  depends_on = [google_artifact_registry_repository_iam_member.access]
 }

--- a/modules/registry/outputs.tf
+++ b/modules/registry/outputs.tf
@@ -17,8 +17,3 @@ output "registry_image_path" {
   description = "Path to registry repository images (ex: example_repo-docker.pkg.dev/my-project/dagster-images)"
   value       = "${google_artifact_registry_repository.default.location}-docker.pkg.dev/${google_artifact_registry_repository.default.project}/${google_artifact_registry_repository.default.repository_id}"
 }
-
-output "registry_image_pull_secret" {
-  description = "Name of Kubernetes secret with Docker config to pull private images from Artifact Registry"
-  value       = kubernetes_secret.image_pull_secret.metadata[0].name
-}

--- a/modules/registry/variables.tf
+++ b/modules/registry/variables.tf
@@ -12,8 +12,3 @@ variable "service_account" {
   description = "Service account used to grant registry IAM membership."
   type        = object({ email = string })
 }
-
-variable "service_account_credentials" {
-  description = "Service account json key to grant permissions for registry image pulling."
-  type        = string
-}

--- a/modules/service_account/main.tf
+++ b/modules/service_account/main.tf
@@ -27,12 +27,6 @@ resource "google_service_account" "default" {
   description  = "Used by GKE node pools in ${var.namespace}."
 }
 
-resource "google_service_account_key" "default" {
-  service_account_id = google_service_account.default.name
-
-  depends_on = [google_service_account.default]
-}
-
 locals {
   roles = [
     "roles/monitoring.viewer",

--- a/modules/service_account/outputs.tf
+++ b/modules/service_account/outputs.tf
@@ -1,8 +1,3 @@
-output "service_account_credentials" {
-  value       = base64decode(google_service_account_key.default.private_key)
-  description = "The private key of the service account."
-}
-
 output "service_account" {
   value       = google_service_account.default
   description = "The service account."

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,11 +45,6 @@ output "registry_image_path" {
   value       = module.registry.registry_image_path
 }
 
-output "registry_image_pull_secret" {
-  description = "Name of Kubernetes secret containing Docker config with permissions to pull from private Artifact Registry repository"
-  value       = module.registry.registry_image_pull_secret
-}
-
 output "network_name" {
   description = "Name of provisioned VPC network"
   value       = module.networking.network.name


### PR DESCRIPTION
## Summary

Replaces the `dockerconfig.json` SA key approach for Artifact Registry image pulls with GKE Workload Identity node-level access.

**Root cause of the old approach:** `modules/registry` granted only `roles/viewer` to the node SA, which does not include `artifactregistry.repositories.downloadArtifacts`. Because the node SA couldn't pull images on its own, a `kubernetes_secret` of type `dockerconfigjson` was created from a rotating SA key and passed as `imagePullSecrets` to every Dagster pod.

**What this PR does:**
- Grants `roles/artifactregistry.reader` (instead of `roles/viewer`) to the GKE node SA on the GAR repository — this is the permission kubelet needs to pull images without any secret
- Removes `kubernetes_secret.image_pull_secret` from `modules/registry`
- Removes `google_service_account_key` from `modules/service_account` (no more long-lived SA keys)
- Removes the `registry_image_pull_secret` output (breaking change → bump to v3.0.0)

**Breaking change:** The `registry_image_pull_secret` output is removed. Callers must remove `registry_image_pull_secret` from their module inputs and set `imagePullSecrets = []` in their Helm values.

## Test plan

- [ ] Tag v3.0.0 after merge so the Terraform Registry publishes the new version
- [ ] Apply the updated module version on dev/staging first
- [ ] Verify a Dagster pod starts cleanly: `kubectl describe pod <dagster-webserver-*>` shows no `imagePullBackOff` and no `imagePullSecrets`
- [ ] Verify `kubectl get secret artifact-registry` returns `NotFound` after the Terraform state is cleaned up

🤖 Generated with [Claude Code](https://claude.ai/claude-code)