### PR TITLE
ci: Use Data Team Bot app token for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ jobs:
     # Skip running release workflow on forks
     if: github.repository_owner == 'wandb'
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.DATA_TEAM_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.DATA_TEAM_BOT_PRIVATE_KEY }}
+          owner: wandb
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -28,4 +36,4 @@ jobs:
             @semantic-release/git@10.0.1
             conventional-changelog-conventionalcommits@4.6.3
         env:
-          GITHUB_TOKEN: ${{ secrets.WANDB_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     # Skip running release workflow on forks
     if: github.repository_owner == 'wandb'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Generate GitHub App Token
         id: app-token


### PR DESCRIPTION
## What

Replace the `WANDB_RELEASE_TOKEN` PAT with a short-lived GitHub App installation token, generated via `actions/create-github-app-token` from the **Data Team Bot** app (`vars.DATA_TEAM_BOT_CLIENT_ID` / `secrets.DATA_TEAM_BOT_PRIVATE_KEY`). Also declares explicit job-level write permissions.

## Why

- PATs are tied to an individual user and expire, requiring manual rotation.
- App tokens are short-lived, scoped, and not tied to a person.
- Matches the pattern already used across other data-team repos (e.g. `wandb/analytics`).

## Notes

- The org-level `DATA_TEAM_BOT_*` var/secret must be granted to this repo, and the app installation needs `contents: write` (push the changelog commit + create releases) and `issues`/`pull-requests: write` (success comments). Confirm before merging.
- Once verified working, `WANDB_RELEASE_TOKEN` can be deleted from repo secrets.