### PR TITLE
ci: Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,12 +6,12 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Render terraform docs and push changes back to PR
-        uses: terraform-docs/gh-actions@main
+        uses: terraform-docs/gh-actions@v1.4.1
         with:
           working-dir: .
           output-file: README.md

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v4.2.0
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'wandb'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0


### PR DESCRIPTION
## What

Bump pinned GitHub Actions to current stable majors:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v2 | v6 |
| `amannn/action-semantic-pull-request` | v4.2.0 | v6.1.1 |
| `terraform-docs/gh-actions` | `@main` (floating) | v1.4.1 |

## Why

- `actions/checkout@v2` runs on the deprecated Node 12 runtime.
- `terraform-docs/gh-actions@main` floats on an unpinned ref; pinning to a release tag makes runs reproducible.

## Out of scope

- `cycjimmy/semantic-release-action` is intentionally left on **v2**. Its v4+ majors changed inputs/Node runtime and pair with `semantic_version: 19.0.2`, so bumping it touches the live release pipeline and needs separate, careful testing.
- `actions/create-github-app-token` is already on the latest major (v3).