### PR TITLE
chore: Upgrade GCP provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ No providers.
 | <a name="module_cluster"></a> [cluster](#module\_cluster) | ./modules/cluster | n/a |
 | <a name="module_database"></a> [database](#module\_database) | ./modules/database | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
-| <a name="module_project_factory_project_services"></a> [project\_factory\_project\_services](#module\_project\_factory\_project\_services) | terraform-google-modules/project-factory/google//modules/project_services | ~> 18.0 |
+| <a name="module_project_factory_project_services"></a> [project\_factory\_project\_services](#module\_project\_factory\_project\_services) | terraform-google-modules/project-factory/google//modules/project_services | ~> 18.2 |
 | <a name="module_registry"></a> [registry](#module\_registry) | ./modules/registry | n/a |
 | <a name="module_service_account"></a> [service\_account](#module\_service\_account) | ./modules/service_account | n/a |
 | <a name="module_storage"></a> [storage](#module\_storage) | ./modules/storage | n/a |
@@ -74,7 +74,6 @@ No resources.
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | Id of provisioned Kubernetes cluster |
 | <a name="output_network_name"></a> [network\_name](#output\_network\_name) | Name of provisioned VPC network |
 | <a name="output_registry_image_path"></a> [registry\_image\_path](#output\_registry\_image\_path) | Docker image path of provisioned Artifact Registry |
-| <a name="output_registry_image_pull_secret"></a> [registry\_image\_pull\_secret](#output\_registry\_image\_pull\_secret) | Name of Kubernetes secret containing Docker config with permissions to pull from private Artifact Registry repository |
 | <a name="output_registry_location"></a> [registry\_location](#output\_registry\_location) | Location of provisioned Artifact Registry |
 | <a name="output_registry_name"></a> [registry\_name](#output\_registry\_name) | Name of provisioned Artifact Registry |
 | <a name="output_service_account"></a> [service\_account](#output\_service\_account) | Service account created to manage and authenticate services. |

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ No providers.
 | <a name="module_cluster"></a> [cluster](#module\_cluster) | ./modules/cluster | n/a |
 | <a name="module_database"></a> [database](#module\_database) | ./modules/database | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
-| <a name="module_project_factory_project_services"></a> [project\_factory\_project\_services](#module\_project\_factory\_project\_services) | terraform-google-modules/project-factory/google//modules/project_services | ~> 18.0 |
+| <a name="module_project_factory_project_services"></a> [project\_factory\_project\_services](#module\_project\_factory\_project\_services) | terraform-google-modules/project-factory/google//modules/project_services | ~> 18.2 |
 | <a name="module_registry"></a> [registry](#module\_registry) | ./modules/registry | n/a |
 | <a name="module_service_account"></a> [service\_account](#module\_service\_account) | ./modules/service_account | n/a |
 | <a name="module_storage"></a> [storage](#module\_storage) | ./modules/storage | n/a |

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -30,7 +30,7 @@ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, < 2.0.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.4 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.9 |
 
@@ -38,7 +38,7 @@ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.18.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | 7.38.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.17.0 |
 
 ## Modules

--- a/example-app/main.tf
+++ b/example-app/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = "~> 7.0"
     }
     helm = {
       source  = "hashicorp/helm"
@@ -59,9 +59,6 @@ provider "helm" {
 locals {
   code_deployment_name = "pipelines"
   code_deployment_port = 9090
-  imagePullSecrets = [{ # tflint-ignore: terraform_naming_convention
-    name = module.dagster_infra.registry_image_pull_secret
-  }]
   user_deployment_values = {
     deployments = [
       {
@@ -75,7 +72,6 @@ locals {
         port               = local.code_deployment_port
       }
     ]
-    imagePullSecrets = local.imagePullSecrets
   }
   service_values = {
     dagsterWebserver = {
@@ -99,7 +95,6 @@ locals {
       postgresqlDatabase = module.dagster_infra.cloudsql_database.name
       postgresqlPassword = module.dagster_infra.cloudsql_database.password
     }
-    imagePullSecrets = local.imagePullSecrets
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # Ensures APIs are all enabled in project
 module "project_factory_project_services" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 18.0"
+  version = "~> 18.2"
 
   project_id = null
 

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = "~> 7.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/modules/service_account/main.tf
+++ b/modules/service_account/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = "~> 7.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = "~> 7.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Upgrade the `hashicorp/google` provider from `~> 6.0` to `~> 7.0` (and `project-factory` module to `~> 18.2` for v7 support). 

The v7 upgrade guide was reviewed; no breaking changes affect the resources used here. 

Also removes a dead `registry_image_pull_secret` reference in `example-app` left over from the Workload Identity migration.