### PR TITLE
fix: Release versions for refactor, chore, and build commits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,21 @@
         [
             "@semantic-release/commit-analyzer",
             {
-                "preset": "conventionalcommits"
+                "preset": "conventionalcommits",
+                "releaseRules": [
+                    {
+                        "type": "refactor",
+                        "release": "patch"
+                    },
+                    {
+                        "type": "chore",
+                        "release": "patch"
+                    },
+                    {
+                        "type": "build",
+                        "release": "patch"
+                    }
+                ]
             }
         ],
         [


### PR DESCRIPTION
## Treat dependency upgrades as patch releases

Adds custom `releaseRules` to `@semantic-release/commit-analyzer` so `refactor`, `chore`, and `build` commits each cut a **patch** release. `feat` (minor), `fix`/`perf`/`revert` (patch), and breaking changes (major) are unchanged.

`chore` isn't necessarily a patch by default, but in this repo dependency/provider upgrades land as `chore`/`build` commits and meaningfully change what consumers pull in, so they should cut patch releases.

Using a `fix:` commit here so this PR itself cuts a release. Which covers the previous `chore:` Google provider v7 upgrade that didn't release under the old rules.

No infinite-loop risk: the bot's own `chore(release): … [skip ci]` commit is skipped by GitHub Actions and sits at the release tag, so it produces no new release.