### PR TITLE
feat: Add `cluster_secret_manager_addon_enabled` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ No resources.
 | <a name="input_cluster_compute_machine_type"></a> [cluster\_compute\_machine\_type](#input\_cluster\_compute\_machine\_type) | Compute machine type to deploy cluster nodes on. | `string` | `"e2-standard-2"` | no |
 | <a name="input_cluster_monitoring_components"></a> [cluster\_monitoring\_components](#input\_cluster\_monitoring\_components) | Components to enable in the GKE monitoring stack. | `list(string)` | <pre>[<br/>  "SYSTEM_COMPONENTS"<br/>]</pre> | no |
 | <a name="input_cluster_node_pool_max_node_count"></a> [cluster\_node\_pool\_max\_node\_count](#input\_cluster\_node\_pool\_max\_node\_count) | Max number of nodes cluster can scale up to. | `number` | `2` | no |
+| <a name="input_cluster_secret_manager_addon_enabled"></a> [cluster\_secret\_manager\_addon\_enabled](#input\_cluster\_secret\_manager\_addon\_enabled) | Whether to enable the Secret Manager add-on for the GKE cluster. | `bool` | `false` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Indicates whether or not storage and databases have deletion protection enabled | `bool` | `true` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | The domain in which your Google Groups are defined. | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace used as a prefix for all resources | `string` | n/a | yes |
@@ -146,6 +147,7 @@ No resources.
 | <a name="input_cluster_compute_machine_type"></a> [cluster\_compute\_machine\_type](#input\_cluster\_compute\_machine\_type) | Compute machine type to deploy cluster nodes on. | `string` | `"e2-standard-2"` | no |
 | <a name="input_cluster_monitoring_components"></a> [cluster\_monitoring\_components](#input\_cluster\_monitoring\_components) | Components to enable in the GKE monitoring stack. | `list(string)` | <pre>[<br/>  "SYSTEM_COMPONENTS"<br/>]</pre> | no |
 | <a name="input_cluster_node_pool_max_node_count"></a> [cluster\_node\_pool\_max\_node\_count](#input\_cluster\_node\_pool\_max\_node\_count) | Max number of nodes cluster can scale up to. | `number` | `2` | no |
+| <a name="input_cluster_secret_manager_addon_enabled"></a> [cluster\_secret\_manager\_addon\_enabled](#input\_cluster\_secret\_manager\_addon\_enabled) | Whether to enable the Secret Manager add-on for the GKE cluster. | `bool` | `false` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Indicates whether or not storage and databases have deletion protection enabled | `bool` | `true` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | The domain in which your Google Groups are defined. | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace used as a prefix for all resources | `string` | n/a | yes |

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -38,7 +38,7 @@ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 7.38.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 7.40.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.17.0 |
 
 ## Modules

--- a/example-app/main.tf
+++ b/example-app/main.tf
@@ -37,6 +37,7 @@ module "dagster_infra" {
   # cloudsql_availability_type (default ZONAL)
   # cluster_compute_machine_type (default e2-standard-2)
   # cluster_node_pool_max_node_count (default 2)
+  # cluster_secret_manager_addon_enabled (default false)
   # deletion_protection (default true)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ module "project_factory_project_services" {
 
   project_id = null
 
-  activate_apis = [
+  activate_apis = concat([
     "iam.googleapis.com",               # Service accounts
     "logging.googleapis.com",           # Logging
     "sqladmin.googleapis.com",          # Database
@@ -15,7 +15,7 @@ module "project_factory_project_services" {
     "artifactregistry.googleapis.com",  # Artifact Registry
     "container.googleapis.com",         # Kubernetes
     "compute.googleapis.com"            # Kubernetes
-  ]
+  ], var.cluster_secret_manager_addon_enabled ? ["secretmanager.googleapis.com"] : [])
   disable_dependent_services  = false
   disable_services_on_destroy = false
 }
@@ -45,19 +45,20 @@ module "networking" {
 }
 
 module "cluster" {
-  source                           = "./modules/cluster"
-  namespace                        = var.namespace
-  project_id                       = var.project_id
-  cluster_compute_machine_type     = var.cluster_compute_machine_type
-  cluster_node_pool_max_node_count = var.cluster_node_pool_max_node_count
-  domain                           = var.domain
-  cluster_monitoring_components    = var.cluster_monitoring_components
+  source                               = "./modules/cluster"
+  namespace                            = var.namespace
+  project_id                           = var.project_id
+  cluster_compute_machine_type         = var.cluster_compute_machine_type
+  cluster_node_pool_max_node_count     = var.cluster_node_pool_max_node_count
+  domain                               = var.domain
+  cluster_monitoring_components        = var.cluster_monitoring_components
+  cluster_secret_manager_addon_enabled = var.cluster_secret_manager_addon_enabled
 
   network         = module.networking.network
   subnetwork      = module.networking.subnetwork
   service_account = module.service_account.service_account
 
-  depends_on = [module.networking, module.service_account]
+  depends_on = [module.networking, module.project_factory_project_services, module.service_account]
 }
 
 module "database" {

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -32,6 +32,14 @@ resource "google_container_cluster" "default" {
     channel = "STABLE"
   }
 
+  dynamic "secret_manager_config" {
+    for_each = var.cluster_secret_manager_addon_enabled ? [true] : []
+
+    content {
+      enabled = true
+    }
+  }
+
   monitoring_config {
     enable_components = var.cluster_monitoring_components
   }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -24,6 +24,12 @@ variable "cluster_monitoring_components" {
   default     = []
 }
 
+variable "cluster_secret_manager_addon_enabled" {
+  description = "Whether to enable the Secret Manager add-on for the GKE cluster."
+  type        = bool
+  default     = false
+}
+
 variable "service_account" {
   description = "The service account associated with the GKE cluster instances that host Dagster."
   type        = object({ email = string })

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,12 @@ variable "cluster_monitoring_components" {
   default     = ["SYSTEM_COMPONENTS"]
 }
 
+variable "cluster_secret_manager_addon_enabled" {
+  description = "Whether to enable the Secret Manager add-on for the GKE cluster."
+  type        = bool
+  default     = false
+}
+
 variable "domain" {
   description = "The domain in which your Google Groups are defined."
   type        = string


### PR DESCRIPTION
## What
- Add `cluster_secret_manager_addon_enabled` to optionally enable GKE's managed Secret Manager add-on on the module-created cluster.
- When the toggle is enabled, activate `secretmanager.googleapis.com` before cluster creation/update so the add-on API dependency is explicit.
- Thread the toggle through the root module, cluster submodule, example app, and generated docs. Default stays `false`, so existing module consumers do not opt in implicitly.

## Why
The add-on supports existing clusters through a GKE update path, but callers should still confirm their cluster version meets the Parameter Manager requirement before enabling it.

## Verify
- `terraform fmt -check -recursive` — passes.
- `terraform init -backend=false -input=false && terraform validate` — root module passes.
- `terraform -chdir=example-app init -backend=false -input=false && terraform -chdir=example-app validate` — example app passes.
- `uvx pre-commit run --all-files` — EOF, trailing whitespace, Terraform validate, Terraform fmt, and Terraform docs pass; repo-wide tflint still fails on pre-existing `modules/networking` required-version/provider warnings unrelated to this diff.
- CI: `docs` passed on PR #39.
- Checked Terraform Google provider behavior while planning rollout: `google_container_cluster.secret_manager_config` is handled by an update request (`DesiredSecretManagerConfig`), not a ForceNew cluster replacement.

No Terraform apply, normal TFC run, or GKE update was triggered.
