### PR TITLE
refactor: Add Secret Manager rotation variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ No resources.
 | <a name="input_cluster_monitoring_components"></a> [cluster\_monitoring\_components](#input\_cluster\_monitoring\_components) | Components to enable in the GKE monitoring stack. | `list(string)` | <pre>[<br/>  "SYSTEM_COMPONENTS"<br/>]</pre> | no |
 | <a name="input_cluster_node_pool_max_node_count"></a> [cluster\_node\_pool\_max\_node\_count](#input\_cluster\_node\_pool\_max\_node\_count) | Max number of nodes cluster can scale up to. | `number` | `2` | no |
 | <a name="input_cluster_secret_manager_addon_enabled"></a> [cluster\_secret\_manager\_addon\_enabled](#input\_cluster\_secret\_manager\_addon\_enabled) | Whether to enable the Secret Manager add-on for the GKE cluster. | `bool` | `false` | no |
+| <a name="input_cluster_secret_manager_rotation_enabled"></a> [cluster\_secret\_manager\_rotation\_enabled](#input\_cluster\_secret\_manager\_rotation\_enabled) | Whether to enable automatic rotation for Secret Manager CSI volumes. Enabling rotation also enables the Secret Manager add-on. | `bool` | `false` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Indicates whether or not storage and databases have deletion protection enabled | `bool` | `true` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | The domain in which your Google Groups are defined. | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace used as a prefix for all resources | `string` | n/a | yes |
@@ -148,6 +149,7 @@ No resources.
 | <a name="input_cluster_monitoring_components"></a> [cluster\_monitoring\_components](#input\_cluster\_monitoring\_components) | Components to enable in the GKE monitoring stack. | `list(string)` | <pre>[<br/>  "SYSTEM_COMPONENTS"<br/>]</pre> | no |
 | <a name="input_cluster_node_pool_max_node_count"></a> [cluster\_node\_pool\_max\_node\_count](#input\_cluster\_node\_pool\_max\_node\_count) | Max number of nodes cluster can scale up to. | `number` | `2` | no |
 | <a name="input_cluster_secret_manager_addon_enabled"></a> [cluster\_secret\_manager\_addon\_enabled](#input\_cluster\_secret\_manager\_addon\_enabled) | Whether to enable the Secret Manager add-on for the GKE cluster. | `bool` | `false` | no |
+| <a name="input_cluster_secret_manager_rotation_enabled"></a> [cluster\_secret\_manager\_rotation\_enabled](#input\_cluster\_secret\_manager\_rotation\_enabled) | Whether to enable automatic rotation for Secret Manager CSI volumes. Enabling rotation also enables the Secret Manager add-on. | `bool` | `false` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Indicates whether or not storage and databases have deletion protection enabled | `bool` | `true` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | The domain in which your Google Groups are defined. | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace used as a prefix for all resources | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ module "project_factory_project_services" {
     "artifactregistry.googleapis.com",  # Artifact Registry
     "container.googleapis.com",         # Kubernetes
     "compute.googleapis.com"            # Kubernetes
-  ], var.cluster_secret_manager_addon_enabled ? ["secretmanager.googleapis.com"] : [])
+  ], var.cluster_secret_manager_addon_enabled || var.cluster_secret_manager_rotation_enabled ? ["secretmanager.googleapis.com"] : [])
   disable_dependent_services  = false
   disable_services_on_destroy = false
 }
@@ -45,14 +45,15 @@ module "networking" {
 }
 
 module "cluster" {
-  source                               = "./modules/cluster"
-  namespace                            = var.namespace
-  project_id                           = var.project_id
-  cluster_compute_machine_type         = var.cluster_compute_machine_type
-  cluster_node_pool_max_node_count     = var.cluster_node_pool_max_node_count
-  domain                               = var.domain
-  cluster_monitoring_components        = var.cluster_monitoring_components
-  cluster_secret_manager_addon_enabled = var.cluster_secret_manager_addon_enabled
+  source                                  = "./modules/cluster"
+  namespace                               = var.namespace
+  project_id                              = var.project_id
+  cluster_compute_machine_type            = var.cluster_compute_machine_type
+  cluster_node_pool_max_node_count        = var.cluster_node_pool_max_node_count
+  domain                                  = var.domain
+  cluster_monitoring_components           = var.cluster_monitoring_components
+  cluster_secret_manager_addon_enabled    = var.cluster_secret_manager_addon_enabled
+  cluster_secret_manager_rotation_enabled = var.cluster_secret_manager_rotation_enabled
 
   network         = module.networking.network
   subnetwork      = module.networking.subnetwork

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -33,10 +33,18 @@ resource "google_container_cluster" "default" {
   }
 
   dynamic "secret_manager_config" {
-    for_each = var.cluster_secret_manager_addon_enabled ? [true] : []
+    for_each = var.cluster_secret_manager_addon_enabled || var.cluster_secret_manager_rotation_enabled ? [true] : []
 
     content {
       enabled = true
+
+      dynamic "rotation_config" {
+        for_each = var.cluster_secret_manager_rotation_enabled ? [true] : []
+
+        content {
+          enabled = true
+        }
+      }
     }
   }
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -30,6 +30,12 @@ variable "cluster_secret_manager_addon_enabled" {
   default     = false
 }
 
+variable "cluster_secret_manager_rotation_enabled" {
+  description = "Whether to enable automatic rotation for Secret Manager CSI volumes. Enabling rotation also enables the Secret Manager add-on."
+  type        = bool
+  default     = false
+}
+
 variable "service_account" {
   description = "The service account associated with the GKE cluster instances that host Dagster."
   type        = object({ email = string })

--- a/variables.tf
+++ b/variables.tf
@@ -79,6 +79,12 @@ variable "cluster_secret_manager_addon_enabled" {
   default     = false
 }
 
+variable "cluster_secret_manager_rotation_enabled" {
+  description = "Whether to enable automatic rotation for Secret Manager CSI volumes. Enabling rotation also enables the Secret Manager add-on."
+  type        = bool
+  default     = false
+}
+
 variable "domain" {
   description = "The domain in which your Google Groups are defined."
   type        = string


### PR DESCRIPTION
## What
- Add `cluster_secret_manager_rotation_enabled` to enable GKE Secret Manager CSI automatic rotation.
- Make rotation implicitly enable the Secret Manager add-on and API while preserving the existing default-off behavior.
- Use GKE's native default rotation interval (two minutes).

## Why
Parameter Manager `versions/latest` is resolved only when a pod mounts the CSI volume today. Existing Dagster pods stay pinned to their original version because the cluster's CSI driver runs with `--enable-secret-rotation=false`.

This PR adds upstream module support only. Enabling it is intentionally deferred until a module release is available.

## Verify
`ASDF_PYTHON_VERSION=3.13.5 ASDF_PRE_COMMIT_VERSION=3.8.0 pre-commit run --files README.md main.tf variables.tf modules/cluster/main.tf modules/cluster/variables.tf` — all hooks pass.
